### PR TITLE
all: migrate to upstreamed v2 benchfmt

### DIFF
--- a/cmd/csv-to-benchfmt/main.go
+++ b/cmd/csv-to-benchfmt/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strconv"
 
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 func main() {
@@ -34,9 +34,9 @@ func main() {
 		}
 
 		r := benchfmt.Result{
-			FullName: []byte(record[0]),
-			Iters:    1,
-			Values:   make([]benchfmt.Value, 0),
+			Name:   []byte(record[0]),
+			Iters:  1,
+			Values: make([]benchfmt.Value, 0),
 		}
 		// Skip label and count.
 		for j := 2; j < len(record); j++ {

--- a/cmd/normalize-benchfmt/main.go
+++ b/cmd/normalize-benchfmt/main.go
@@ -101,7 +101,7 @@ import (
 
 	"github.com/prattmic/benchfmt-convert/gtest"
 	"github.com/prattmic/benchfmt-convert/perf"
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 type parser func(string) (benchfmt.Result, bool)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/prattmic/benchfmt-convert
 
-go 1.17
-
-replace golang.org/x/perf/v2 => github.com/aclements/go-perf-v2/v2 v2.0.0-20201114230402-4cc84854ceef
+go 1.23.5
 
 require (
 	github.com/google/go-cmp v0.5.9
-	golang.org/x/perf/v2 v2.0.0-00010101000000-000000000000
+	golang.org/x/perf v0.0.0-20250106172127-400946f43c82
 )
 
-require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+require github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,6 @@
-github.com/aclements/go-moremath v0.0.0-20190830160640-d16893ddf098/go.mod h1:idZL3yvz4kzx1dsBOAC+oYv6L92P1oFEhUXUB1A/lwQ=
-github.com/aclements/go-perf-v2/v2 v2.0.0-20201114230402-4cc84854ceef h1:ZaZLIZN07sParHKjlguJq6WKwKR7F/vUEc+L70ll1V8=
-github.com/aclements/go-perf-v2/v2 v2.0.0-20201114230402-4cc84854ceef/go.mod h1:CS1MQBFM43R8qCxHfxwulrTYejejhdCdMhrwc5BCMoo=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/perf v0.0.0-20250106172127-400946f43c82 h1:cntvEEbGexov/BId760utCq7Mtu7iJG4lRr/0z+V7Z4=
+golang.org/x/perf v0.0.0-20250106172127-400946f43c82/go.mod h1:q/JkMABA9XXpcvcwKP7xYHRk8KsZBPSXrV8tG4DEMGI=

--- a/gtest/gtest.go
+++ b/gtest/gtest.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 var (
@@ -40,8 +40,8 @@ func Line(s string) (benchfmt.Result, bool) {
 	}
 
 	r := benchfmt.Result{
-		FullName: []byte(name),
-		Iters:    int(i),
+		Name:  []byte(name),
+		Iters: int(i),
 	}
 
 	wall := m[2]

--- a/gtest/gtest_test.go
+++ b/gtest/gtest_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 ///^BM_.*\s+[0-9]+\s+.*\s+[0-9]+\s+.*\s+[0-9]+$/ {
@@ -26,8 +26,8 @@ func TestGTest(t *testing.T) {
 			line:  "BM_Stat/64/real_time       16770 ns        16593 ns        42186",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Stat/64/real_time"),
-				Iters:    42186,
+				Name:  []byte("Stat/64/real_time"),
+				Iters: 42186,
 				Values: []benchfmt.Value{
 					{
 						Value: 16770,
@@ -45,8 +45,8 @@ func TestGTest(t *testing.T) {
 			line:  "BM_Stat/64/real_time       16770 ns        16593 ns        42186  ",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Stat/64/real_time"),
-				Iters:    42186,
+				Name:  []byte("Stat/64/real_time"),
+				Iters: 42186,
 				Values: []benchfmt.Value{
 					{
 						Value: 16770,
@@ -64,8 +64,8 @@ func TestGTest(t *testing.T) {
 			line:  "BM_LargeConsistent                 4.69           4.69   500000000  ",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("LargeConsistent"),
-				Iters:    500000000,
+				Name:  []byte("LargeConsistent"),
+				Iters: 500000000,
 				Values: []benchfmt.Value{
 					{
 						Value: 4.69,
@@ -83,8 +83,8 @@ func TestGTest(t *testing.T) {
 			line:  "BM_Read/1/real_time              3820 ns         2757 ns       184963 bytes_per_second=255.676k/s",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Read/1/real_time"),
-				Iters:    184963,
+				Name:  []byte("Read/1/real_time"),
+				Iters: 184963,
 				Values: []benchfmt.Value{
 					{
 						Value: 3820,

--- a/perf/perf.go
+++ b/perf/perf.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"unicode"
 
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 var (
@@ -95,8 +95,8 @@ func Line(s string) (benchfmt.Result, bool) {
 	}
 
 	r := benchfmt.Result{
-		FullName: []byte(capitalize(name)),
-		Iters:    1,
+		Name:  []byte(capitalize(name)),
+		Iters: 1,
 		Values: []benchfmt.Value{
 			{
 				Value: v,

--- a/perf/perf_test.go
+++ b/perf/perf_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"golang.org/x/perf/v2/benchfmt"
+	"golang.org/x/perf/benchfmt"
 )
 
 func TestPerf(t *testing.T) {
@@ -24,8 +24,8 @@ func TestPerf(t *testing.T) {
 			line:  "          1,291,018      cycles                    #    1.167 GHz",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Cycles"),
-				Iters:    1,
+				Name:  []byte("Cycles"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 1291018,
@@ -39,8 +39,8 @@ func TestPerf(t *testing.T) {
 			line:  "          1,291,018      cycles:u                    #    1.167 GHz",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Cycles:u"),
-				Iters:    1,
+				Name:  []byte("Cycles:u"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 1291018,
@@ -54,8 +54,8 @@ func TestPerf(t *testing.T) {
 			line:  "     2,651,008,697      L1-dcache-loads",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("L1-dcache-loads"),
-				Iters:    1,
+				Name:  []byte("L1-dcache-loads"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 2651008697,
@@ -69,8 +69,8 @@ func TestPerf(t *testing.T) {
 			line:  "        32,163,995      L1-icache-load-misses                                                   (72.21%)",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("L1-icache-load-misses"),
-				Iters:    1,
+				Name:  []byte("L1-icache-load-misses"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 32163995,
@@ -84,8 +84,8 @@ func TestPerf(t *testing.T) {
 			line:  "               1.11 msec task-clock                #    0.001 CPUs utilized",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Task-clock"),
-				Iters:    1,
+				Name:  []byte("Task-clock"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 0.00111,
@@ -99,8 +99,8 @@ func TestPerf(t *testing.T) {
 			line:  "               1.11 msec task-clock:u                #    0.001 CPUs utilized",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Task-clock:u"),
-				Iters:    1,
+				Name:  []byte("Task-clock:u"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 0.00111,
@@ -114,8 +114,8 @@ func TestPerf(t *testing.T) {
 			line:  "      1656.917143299 seconds time elapsed",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("Wall-time"),
-				Iters:    1,
+				Name:  []byte("Wall-time"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 1656.917143299,
@@ -129,8 +129,8 @@ func TestPerf(t *testing.T) {
 			line:  "      1656.917143299 seconds user",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("User-time"),
-				Iters:    1,
+				Name:  []byte("User-time"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 1656.917143299,
@@ -144,8 +144,8 @@ func TestPerf(t *testing.T) {
 			line:  "      1656.917143299 seconds sys",
 			match: true,
 			want: benchfmt.Result{
-				FullName: []byte("System-time"),
-				Iters:    1,
+				Name:  []byte("System-time"),
+				Iters: 1,
 				Values: []benchfmt.Value{
 					{
 						Value: 1656.917143299,


### PR DESCRIPTION
https://go.dev/cl/283614 upstreamed this package into x/perf.

Change-Id: I6a6a636c45e1ad2c07db9ed3793e2ebc397b21f2